### PR TITLE
feat: Add i18n

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,26 +3,29 @@ import reactLogo from "./assets/react.svg";
 import { invoke } from "@tauri-apps/api/tauri";
 import { MyTimer } from "./timer";
 import "./App.css";
+import { getLangDescription } from "./i18n/i18n";
 
 function App() {
   const [time, setTime] = useState(0);
   const [salaryParSec, setSalaryParSec] = useState(300);
   const [started, setStarted] = useState(false);
+  const [lang, setLang] = useState('ja');
 
   async function greet() {
     // Learn more about Tauri commands at https://tauri.app/v1/guides/features/command
     // setGreetMsg(await invoke("greet", { name }));
   }
 
+  const desc = getLangDescription(lang)
   return (
     <div className="container">
       { 
         started
-        ? <MyTimer seconds={time} salaryParSec={salaryParSec}/> 
+        ? <MyTimer seconds={time} salaryParSec={salaryParSec} desc={desc}/> 
         : 
         <div className="row">
         <div>
-          <p>労働時間を入力</p>
+          <p>{desc.Time}</p>
           <input
             id="time-input"
             onChange={(e) => {
@@ -31,9 +34,9 @@ function App() {
                 setTime(time);
               }
             }}
-            placeholder="Enter a seconds..."
+            placeholder={desc.TimePlaceHolder}
           />
-          <p>秒間の増加額を入力</p>
+          <p>{desc.SalaryParSec}</p>
           <input
             id="salary-input"
             onChange={(e) => {
@@ -45,17 +48,24 @@ function App() {
               }
             }}
             value={salaryParSec}
-            placeholder="Enter a salary par seconds..."
+            placeholder={desc.SalaryParSecHolder}
           />
           <p></p>
           <button type="button" onClick={() => {
             if (Number.isInteger(time) && time > 0 && Number.isInteger(salaryParSec)) {
               setStarted(true);
             } else {
-              window.alert("整数値で入力してください");
+              window.alert(desc.FloatError);
             }
-            }}>
+          }}>
             Start
+          </button>
+          <p></p>
+          <button type="button" onClick={() => {setLang('en');}}>
+            {'English'}
+          </button>
+          <button type="button" onClick={() => {setLang('ja');}}>
+            {'日本語'}
           </button>
         </div>
       </div>

--- a/src/i18n/description.ts
+++ b/src/i18n/description.ts
@@ -1,0 +1,27 @@
+
+export type Descritption = {
+    Title: string;
+    Time: string;
+    TimePlaceHolder: string;
+    SalaryParSec: string;
+    SalaryParSecHolder: string;
+    FloatError: string;
+    RemainingTime: string;
+    isWorking: string;
+    isNotWorking: string;
+}
+
+export function initDescription():Descritption{
+    const desc:Descritption={
+        Title: "",
+        Time: "",
+        TimePlaceHolder: "",
+        SalaryParSec: "",
+        SalaryParSecHolder: "",
+        FloatError: "",
+        RemainingTime: "",
+        isWorking: "",
+        isNotWorking: "",
+    }
+    return desc
+}

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -1,0 +1,24 @@
+import { Descritption, initDescription } from "./description";
+import { en } from "./locales/en";
+import { ja } from "./locales/ja";
+
+const Languages = [
+    'en',
+    'ja',
+]
+
+const Descriptions = {
+    en,
+    ja,
+}
+
+export function getLangDescription(language: string): Descritption {
+    let desc:Descritption=initDescription();
+
+    Languages.map((lang) => {
+        desc = Object.hasOwn(Descriptions, lang)
+        ? Descriptions[language as keyof typeof Descriptions]
+        : Descriptions.en;//console.log(`${lang} is not supported`);
+    })
+    return desc;
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1,0 +1,13 @@
+import { Descritption } from "../description";
+
+export const en: Descritption = {
+    Title: "Working",
+    Time: "Working hours in seconds",
+    TimePlaceHolder: "Enter a seconds...",
+    SalaryParSec: "Salary Par Second",
+    SalaryParSecHolder: "Enter a salary par seconds...",
+    FloatError: "Please Enter Integer!",
+    RemainingTime: "Remaining Working hours",
+    isWorking: "Working",
+    isNotWorking: "Not working",
+}

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -1,0 +1,13 @@
+import { Descritption } from "../description";
+
+export const ja: Descritption = {
+    Title: "労働中",
+    Time: "労働時間を入力",
+    TimePlaceHolder: "Enter a seconds...",
+    SalaryParSec: "秒間の増加額を入力",
+    SalaryParSecHolder: "Enter a salary par seconds...",
+    FloatError: "整数値で入力してください",
+    RemainingTime: "労働残り時間",
+    isWorking: "Working",
+    isNotWorking: "Not working",
+}

--- a/src/timer.tsx
+++ b/src/timer.tsx
@@ -1,11 +1,12 @@
 import { useTimer } from "react-timer-hook";
+import { Descritption } from "./i18n/description";
 
 const timerFormat = (n: number) => n.toString().padStart(2, "0");
 
 
 function MyTimerInternal(
-  { expiryTimestamp, initialSeconds, salaryParSec }:
-  { expiryTimestamp: Date, initialSeconds: number, salaryParSec: number }
+  { expiryTimestamp, initialSeconds, salaryParSec, desc }:
+  { expiryTimestamp: Date, initialSeconds: number, salaryParSec: number, desc:Descritption }
   ) {
     const {
       seconds,
@@ -30,13 +31,13 @@ function MyTimerInternal(
     const gotMoney = elapsedSeconds * salaryParSec;
     return (
       <div style={{ textAlign: "center" }}>
-        <h1>労働残り時間</h1>
+        <h1>{desc.RemainingTime}</h1>
         <br/>
         <div style={{ fontSize: "6.25rem" }}>
           <span>{timerFormat((days * 24 + hours) * 60 + minutes)}</span>:<span>{timerFormat(seconds)}</span>
         </div>
         <br/>
-        <p>{isRunning ? "Working" : "Not working"}</p>
+        <p>{isRunning ? desc.isWorking : desc.isNotWorking }</p>
         <h1>{formatter.format(gotMoney)}</h1>
         <button onClick={start}>Start</button>
         <button onClick={pause}>Pause</button>
@@ -55,8 +56,8 @@ function MyTimerInternal(
     );
 }
 
-export function MyTimer({ seconds, salaryParSec }: { seconds: number, salaryParSec: number }) {
+export function MyTimer({ seconds, salaryParSec, desc }: { seconds: number, salaryParSec: number, desc: Descritption }) {
     const time = new Date();
     time.setSeconds(time.getSeconds() + seconds);
-    return <MyTimerInternal expiryTimestamp={time} initialSeconds={seconds} salaryParSec={salaryParSec}/>
+    return <MyTimerInternal expiryTimestamp={time} initialSeconds={seconds} salaryParSec={salaryParSec} desc={desc}/>
 }


### PR DESCRIPTION
# Description
- 言語切り替え機能の追加
  - en/ja対応

## Environments
```sh
$ cargo -V
1.66.1

$ cargo-tauri -V
tauri-cli 1.2.2

$ yarn -V
1.22.19
```

# Test
- ローカル環境にて、言語切り替え機能が動作していることを確認済み。
  - ビルド手順
    ```sh
    cd src-tauri
    yarn build
    cargo run
    ```
- 言語切り替えボタン押下後のスクリーンショットは以下。

<img src="https://user-images.githubusercontent.com/42852440/212736281-87b4ff8e-be6f-4c16-8d50-56281c13d232.png" width="40%"> <img src="https://user-images.githubusercontent.com/42852440/212736298-4b7aef70-e6ef-4d29-9fe1-1b90e1278c61.png" width="40%">

# Backlogs
- index.html中のTitle変更は未対応

# Link
- i18n対応で参考にした例
  - [VSCode](https://github.com/microsoft/vscode/blob/d627ebb4080bca141d6a4e6173d782c84e626981/build/lib/i18n.ts#L840)
  - [ant-simple-pro](https://github.com/lgf196/ant-simple-pro/tree/f6613195ab949b067afa57cdf885373d8c6cc58e/react%2Btypescript/src/locales
  )
    - i18next ライブラリもある様子。jsonのためこちらの方が綺麗かも